### PR TITLE
Fixed OAuthAppAuthorization not throwing TransportException

### DIFF
--- a/pypodio2/transport.py
+++ b/pypodio2/transport.py
@@ -62,8 +62,7 @@ class OAuthAppAuthorization(object):
         headers = {'content-type': 'application/x-www-form-urlencoded'}
         response, data = h.request(domain + "/oauth/token", "POST",
                                    urlencode(body), headers=headers)
-        if response['status'] == '200':
-            self.token = OAuthToken(_handle_response(response, data))
+        self.token = OAuthToken(_handle_response(response, data))
 
     def __call__(self):
         return self.token.to_headers()


### PR DESCRIPTION
`OAuthAppAuthorization` does not handle non-200 responses on auth, instead a wrong (or in my case, rejected because of rate limiting) login intent causes nothing to happen until a subsequent intent to call the API results in an `AttributeError` caused by the missing `token`.
I changed it to work like `OAuthAuthorization` -- the exception is thrown inside `_handle_response`.
