### PR TITLE
Allow normal SSL certificate checking

### DIFF
--- a/pypodio2/transport.py
+++ b/pypodio2/transport.py
@@ -40,7 +40,7 @@ class OAuthAuthorization(object):
                 'client_secret': secret,
                 'username': login,
                 'password': password}
-        h = Http(disable_ssl_certificate_validation=True)
+        h = Http()
         headers = {'content-type': 'application/x-www-form-urlencoded'}
         response, data = h.request(domain + "/oauth/token", "POST",
                                    urlencode(body), headers=headers)
@@ -58,7 +58,7 @@ class OAuthAppAuthorization(object):
                 'client_secret': secret,
                 'app_id': app_id,
                 'app_token': app_token}
-        h = Http(disable_ssl_certificate_validation=True)
+        h = Http()
         headers = {'content-type': 'application/x-www-form-urlencoded'}
         response, data = h.request(domain + "/oauth/token", "POST",
                                    urlencode(body), headers=headers)
@@ -108,7 +108,7 @@ class HttpTransport(object):
         self._attribute_stack = []
         self._method = "GET"
         self._posts = []
-        self._http = Http(disable_ssl_certificate_validation=True)
+        self._http = Http()
         self._params = {}
         self._url_template = '%(domain)s/%(generated_url)s'
         self._stack_collapser = "/".join


### PR DESCRIPTION
This fixes issue #27. As far as I can tell api.podio.com has a perfectly valid SSL certificate.