### PR TITLE
Update to areas.Task methods

### DIFF
--- a/pypodio2/areas.py
+++ b/pypodio2/areas.py
@@ -244,11 +244,27 @@ class Task(Area):
         """
         Get tasks endpoint. QueryStrings are kwargs
         """
+        # should deprecate this method
         return self.transport.GET('/task/', **kwargs)
 
+    def find_all(self, **kwargs):
+        """
+        Get all tasks. QueryStrings are kwargs
+        """
+        return self.transport.GET('/task/', **kwargs)
+    
+    def find(self, task_id, **kwargs):
+        """
+        Get the task with the given task_id.
+        
+        :param task_id: Task ID
+        :type task_id: str or int
+        """
+        return self.transport.GET(url='/task/%s' % task_id)
+    
     def delete(self, task_id):
         """
-        Deletes the app with the given id.
+        Deletes the task with the given id.
         
         :param task_id: Task ID
         :type task_id: str or int


### PR DESCRIPTION
Adds a `find` method on the `Task` area to retrieve a single task by the id. This has been named `Task.find` to remain consistent with other areas.  The `get` method is not consistent with other areas though which use `find_all` or `find_all_by_*`. So `find_all` has been added and a comment placed in `get` to deprecate this method.